### PR TITLE
Add basic Node.js backend skeleton

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "smart-notes-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node test/server.test.js"
+  }
+}

--- a/backend/src/data.js
+++ b/backend/src/data.js
@@ -1,0 +1,11 @@
+export const documents = []
+
+export function getAllDocuments() {
+  return documents
+}
+
+export function createDocument({ title, content }) {
+  const doc = { id: String(documents.length + 1), title, content }
+  documents.push(doc)
+  return doc
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,38 @@
+import http from 'http'
+import { getAllDocuments, createDocument } from './data.js'
+
+function jsonResponse(res, statusCode, data) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(data))
+}
+
+export function createApp() {
+  return http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/api/documents') {
+      jsonResponse(res, 200, { documents: getAllDocuments() })
+    } else if (req.method === 'POST' && req.url === '/api/documents') {
+      let body = ''
+      req.on('data', chunk => {
+        body += chunk
+      })
+      req.on('end', () => {
+        try {
+          const { title, content } = JSON.parse(body)
+          const doc = createDocument({ title, content })
+          jsonResponse(res, 201, doc)
+        } catch (err) {
+          jsonResponse(res, 400, { error: 'Invalid JSON' })
+        }
+      })
+    } else {
+      jsonResponse(res, 404, { error: 'Not found' })
+    }
+  })
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const PORT = process.env.PORT || 5000
+  createApp().listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`)
+  })
+}

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -1,0 +1,34 @@
+import { createApp } from '../src/server.js'
+import { once } from 'events'
+import assert from 'assert'
+
+async function run() {
+  const server = createApp().listen(0)
+  await once(server, 'listening')
+  const { port } = server.address()
+
+  let res = await fetch(`http://localhost:${port}/api/documents`)
+  assert.strictEqual(res.status, 200)
+  let data = await res.json()
+  assert.deepStrictEqual(data.documents, [])
+
+  res = await fetch(`http://localhost:${port}/api/documents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Test', content: 'Hello' })
+  })
+  assert.strictEqual(res.status, 201)
+  const doc = await res.json()
+  assert.strictEqual(doc.title, 'Test')
+
+  res = await fetch(`http://localhost:${port}/api/documents`)
+  const data2 = await res.json()
+  assert.strictEqual(data2.documents.length, 1)
+
+  server.close()
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- scaffold backend directory with a simple HTTP server
- add in-memory document store and REST endpoints
- include a small integration test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68479f2bcc708323a536ceb7ff7a919f