### PR TITLE
Add CRUD API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # Smart-Note-Taking-Web-App-Implementation-Guide
-Smart Note-Taking Web App Implementation Guide
+
+This repository contains a simple Node.js backend used to experiment with a smart note taking API.
+It exposes REST endpoints for creating, reading, updating and deleting documents that are stored in
+memory. The server is intended as a starting point for further development.
+
+## Prerequisites
+
+- Node.js 18 or newer
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   cd backend
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm start
+   ```
+
+   The API will be available at `http://localhost:5000` by default.
+
+3. Run the test suite:
+
+   ```bash
+   npm test
+   ```
+
+## API Endpoints
+
+- `GET /api/documents` – list all documents
+- `POST /api/documents` – create a new document (expects JSON `{ title, content }`)
+- `GET /api/documents/:id` – get a document by id
+- `PUT /api/documents/:id` – update a document
+- `DELETE /api/documents/:id` – remove a document
+
+Data is stored in memory so it will reset when the server restarts.
+Consider adding a database or persistence layer for a real application.
+
+## Next Steps
+
+The following improvements are recommended but not yet implemented:
+
+- Use a database (e.g. SQLite, MongoDB) instead of the in-memory array.
+- Create a frontend interface to interact with the API.
+- Expand tests to cover edge cases and database logic once added.
+- Set up continuous integration to run tests automatically.
+
+

--- a/backend/src/data.js
+++ b/backend/src/data.js
@@ -9,3 +9,22 @@ export function createDocument({ title, content }) {
   documents.push(doc)
   return doc
 }
+
+export function getDocumentById(id) {
+  return documents.find(d => d.id === id)
+}
+
+export function updateDocument(id, { title, content }) {
+  const doc = getDocumentById(id)
+  if (!doc) return null
+  if (title !== undefined) doc.title = title
+  if (content !== undefined) doc.content = content
+  return doc
+}
+
+export function deleteDocument(id) {
+  const index = documents.findIndex(d => d.id === id)
+  if (index === -1) return false
+  documents.splice(index, 1)
+  return true
+}

--- a/backend/test/server.test.js
+++ b/backend/test/server.test.js
@@ -21,9 +21,33 @@ async function run() {
   const doc = await res.json()
   assert.strictEqual(doc.title, 'Test')
 
+  const id = doc.id
+
+  res = await fetch(`http://localhost:${port}/api/documents/${id}`)
+  assert.strictEqual(res.status, 200)
+  const single = await res.json()
+  assert.strictEqual(single.id, id)
+
+  res = await fetch(`http://localhost:${port}/api/documents/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title: 'Updated' })
+  })
+  assert.strictEqual(res.status, 200)
+  const updated = await res.json()
+  assert.strictEqual(updated.title, 'Updated')
+
+  res = await fetch(`http://localhost:${port}/api/documents/${id}`, {
+    method: 'DELETE'
+  })
+  assert.strictEqual(res.status, 204)
+
+  res = await fetch(`http://localhost:${port}/api/documents/${id}`)
+  assert.strictEqual(res.status, 404)
+
   res = await fetch(`http://localhost:${port}/api/documents`)
   const data2 = await res.json()
-  assert.strictEqual(data2.documents.length, 1)
+  assert.strictEqual(data2.documents.length, 0)
 
   server.close()
 }


### PR DESCRIPTION
## Summary
- support getting single, updating and deleting documents
- extend data utilities for CRUD operations
- expand tests to cover new routes
- document setup steps and new API endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a34a4ad0832384bc551f31364cbf