### PR TITLE
Enable SQLite storage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,19 @@ memory. The server is intended as a starting point for further development.
 
    The API will be available at `http://localhost:5000` by default.
    Set the `DATA_FILE` environment variable to persist documents to a JSON file.
+   Alternatively, provide a `DB_FILE` path to use a SQLite database.
 
 3. Run the test suite:
 
-   ```bash
-   npm test
-   ```
+  ```bash
+  npm test
+  ```
+
+### Database Configuration
+
+To store notes in SQLite instead of memory, set the `DB_FILE` environment
+variable to the path of a `.db` file before starting the server. The database
+and required table will be created automatically if they do not exist.
 
 ## API Endpoints
 
@@ -47,7 +54,9 @@ Set a `DATA_FILE` path to persist them across sessions, or consider using a data
 
 The following improvements are recommended but not yet implemented:
 
-- Use a database (e.g. SQLite, MongoDB) instead of the in-memory array.
+<!-- Database integration implemented -->
+- Database integration via SQLite is now available. Set `DB_FILE` to a path
+  to use a SQLite database instead of the in-memory array.
 - Create a frontend interface to interact with the API.
 - Expand tests to cover edge cases and database logic once added.
 - Continuous integration is configured with GitHub Actions to run tests automatically.

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,5 +5,8 @@
   "scripts": {
     "start": "node src/server.js",
     "test": "node test/server.test.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.0.0"
   }
 }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -13,13 +13,14 @@ function jsonResponse(res, statusCode, data) {
 }
 
 export function createApp() {
-  return http.createServer((req, res) => {
+  return http.createServer(async (req, res) => {
     const idMatch = req.url.match(/^\/api\/documents\/(\w+)$/)
 
     if (req.method === 'GET' && req.url === '/api/documents') {
-      jsonResponse(res, 200, { documents: getAllDocuments() })
+      const docs = await getAllDocuments()
+      jsonResponse(res, 200, { documents: docs })
     } else if (req.method === 'GET' && idMatch) {
-      const doc = getDocumentById(idMatch[1])
+      const doc = await getDocumentById(idMatch[1])
       if (doc) {
         jsonResponse(res, 200, doc)
       } else {
@@ -30,10 +31,10 @@ export function createApp() {
       req.on('data', chunk => {
         body += chunk
       })
-      req.on('end', () => {
+      req.on('end', async () => {
         try {
           const { title, content } = JSON.parse(body)
-          const doc = createDocument({ title, content })
+          const doc = await createDocument({ title, content })
           jsonResponse(res, 201, doc)
         } catch (err) {
           jsonResponse(res, 400, { error: 'Invalid JSON' })
@@ -42,10 +43,10 @@ export function createApp() {
     } else if ((req.method === 'PUT' || req.method === 'PATCH') && idMatch) {
       let body = ''
       req.on('data', c => { body += c })
-      req.on('end', () => {
+      req.on('end', async () => {
         try {
           const data = JSON.parse(body)
-          const updated = updateDocument(idMatch[1], data)
+          const updated = await updateDocument(idMatch[1], data)
           if (updated) {
             jsonResponse(res, 200, updated)
           } else {
@@ -56,7 +57,7 @@ export function createApp() {
         }
       })
     } else if (req.method === 'DELETE' && idMatch) {
-      const ok = deleteDocument(idMatch[1])
+      const ok = await deleteDocument(idMatch[1])
       if (ok) {
         jsonResponse(res, 204, null)
       } else {

--- a/backend/src/sqliteStore.js
+++ b/backend/src/sqliteStore.js
@@ -1,0 +1,40 @@
+import Database from 'better-sqlite3'
+
+let db
+
+export function init(path) {
+  db = new Database(path)
+  db.prepare(`CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    content TEXT
+  )`).run()
+}
+
+export function getAllDocuments() {
+  return db.prepare('SELECT id, title, content FROM documents').all()
+}
+
+export function createDocument({ title, content }) {
+  const stmt = db.prepare('INSERT INTO documents (title, content) VALUES (?, ?)')
+  const info = stmt.run(title, content)
+  return { id: String(info.lastInsertRowid), title, content }
+}
+
+export function getDocumentById(id) {
+  return db.prepare('SELECT id, title, content FROM documents WHERE id = ?').get(id)
+}
+
+export function updateDocument(id, { title, content }) {
+  const existing = getDocumentById(id)
+  if (!existing) return null
+  const newTitle = title !== undefined ? title : existing.title
+  const newContent = content !== undefined ? content : existing.content
+  db.prepare('UPDATE documents SET title = ?, content = ? WHERE id = ?').run(newTitle, newContent, id)
+  return { id: String(id), title: newTitle, content: newContent }
+}
+
+export function deleteDocument(id) {
+  const result = db.prepare('DELETE FROM documents WHERE id = ?').run(id)
+  return result.changes > 0
+}

--- a/backend/src/store.js
+++ b/backend/src/store.js
@@ -1,15 +1,19 @@
 import * as memory from './data.js'
 import * as fileStore from './fileData.js'
+import * as sqliteStore from './sqliteStore.js'
 
 let store = memory
 
-if (process.env.DATA_FILE) {
+if (process.env.DB_FILE) {
+  sqliteStore.init(process.env.DB_FILE)
+  store = sqliteStore
+} else if (process.env.DATA_FILE) {
   fileStore.init(process.env.DATA_FILE)
   store = fileStore
 }
 
-export const getAllDocuments = store.getAllDocuments
-export const createDocument = store.createDocument
-export const getDocumentById = store.getDocumentById
-export const updateDocument = store.updateDocument
-export const deleteDocument = store.deleteDocument
+export const getAllDocuments = (...args) => store.getAllDocuments(...args)
+export const createDocument = (...args) => store.createDocument(...args)
+export const getDocumentById = (...args) => store.getDocumentById(...args)
+export const updateDocument = (...args) => store.updateDocument(...args)
+export const deleteDocument = (...args) => store.deleteDocument(...args)


### PR DESCRIPTION
## Summary
- add `better-sqlite3` dependency
- implement `sqliteStore` using SQLite for persistence
- switch store based on `DB_FILE` environment variable
- update server to await async store functions
- document how to configure SQLite in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find package 'better-sqlite3')*

------
https://chatgpt.com/codex/tasks/task_e_684a2a63736c8323ad3aec3fc15fb054