### PR TITLE
Add ESLint config for backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ backend.zip
 # Data files
 backend/documents.json
 *.json
+!backend/.eslintrc.json
 
 # Node modules
 node_modules/

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "env": { "node": true, "es2021": true },
+  "extends": "eslint:recommended",
+  "parserOptions": { "ecmaVersion": 12, "sourceType": "module" },
+  "rules": {}
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,8 +8,8 @@
     "test:enhanced": "node test/enhanced.test.js",
     "test:auth": "node test/auth.test.js",
     "test:all": "npm test && npm run test:enhanced && npm run test:auth",
-    "lint": "eslint src/ test/",
-    "lint:fix": "eslint src/ test/ --fix",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json src/ test/",
+    "lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.json src/ test/ --fix",
     "format": "prettier --write src/ test/"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `.eslintrc.json` for backend linting
- allow ESLint config JSON through `.gitignore`
- update `npm run lint` scripts to use the config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a3ca9c4e083238aa396edc919aca7