### PR TITLE
Update AGENTS for next steps section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,8 @@ This document describes the interactions and roles of the AI agents involved in 
     
     **Purpose:** Maintain a bidirectional record of updates and instructions so each agent knows what the other has changed. `codexlastupdate.md` lets Claude Sonnet track Codex's recent updates and read any instructions from Codex, including which dependencies must be installed or unignored for Codex's tests. `claudes4lastupdate.md` informs Codex of Claude Sonnet's latest updates and guidance.
 
+    **Next Steps Tracking:** Codex must include a **Next Steps** section in every `codexlastupdate.md` summarizing the immediate development tasks. Claude Sonnet reads this section whenever it pulls the latest repository state and uses it to determine its next actions.
+
     * **Repository Management:** Always ensure the following core dependencies are present in `backend/package.json` when pushing changes to the repository:
     
     **Production Dependencies:**


### PR DESCRIPTION
## Summary
- instruct Codex to maintain a **Next Steps** section in `codexlastupdate.md`
- instruct Claude Sonnet to read the **Next Steps** section when pulling the latest code

## Testing
- `npm run test:all` *(fails: Cannot find package 'winston')*

------
https://chatgpt.com/codex/tasks/task_e_684a5cf40b888323809055720ccc10fa